### PR TITLE
Upgrade the NuGet version to 32.1.19 - UWP RichTextBox Examples

### DIFF
--- a/Samples/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion.csproj
+++ b/Samples/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion/Automatic Suggestion.csproj
@@ -159,7 +159,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfRichTextBoxAdv.UWP">
-      <Version>18.4.0.30</Version>
+      <Version>32.1.19</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Samples/Automatic Suggestion/Custom Suggestion Provider/Custom Suggestion Provider/Custom Suggestion Provider.csproj
+++ b/Samples/Automatic Suggestion/Custom Suggestion Provider/Custom Suggestion Provider/Custom Suggestion Provider.csproj
@@ -155,7 +155,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfRichTextBoxAdv.UWP">
-      <Version>18.4.0.30</Version>
+      <Version>32.1.19</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Samples/Automatic Suggestion/Multiple Suggestion Provider/Multiple Suggestion Provider/Multiple Suggestion Provider.csproj
+++ b/Samples/Automatic Suggestion/Multiple Suggestion Provider/Multiple Suggestion Provider/Multiple Suggestion Provider.csproj
@@ -159,7 +159,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfRichTextBoxAdv.UWP">
-      <Version>18.4.0.30</Version>
+      <Version>32.1.19</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Samples/Standard RichTextBox/Standard RichTextBox/Standard_RichTextBox.csproj
+++ b/Samples/Standard RichTextBox/Standard RichTextBox/Standard_RichTextBox.csproj
@@ -166,7 +166,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfRichTextBoxAdv.UWP">
-      <Version>18.3.0.51</Version>
+      <Version>32.1.19</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
## Description: ##
Upgraded the NuGet version to 32.1.19 in all projects for UWP RichTextBox Examples repository.